### PR TITLE
.perl

### DIFF
--- a/perl/.perl
+++ b/perl/.perl
@@ -1,0 +1,41 @@
+#!/usr/bin/env perl
+ 
+use strict;
+use warnings;
+ 
+use Encode qw( decode );
+use Getopt::Long;
+use LWP::UserAgent;
+use URI;
+use URI::QueryParam;
+ 
+my $license_key = 'YOUR_LICENSE_KEY';
+my $ip_address  = '24.24.24.24';
+ 
+GetOptions(
+    'license:s' => \$license_key,
+    'ip:s'      => \$ip_address,
+);
+ 
+my $uri = URI->new('https://minfraud.maxmind.com/app/ipauth_http');
+$uri->query_param( l => $license_key );
+$uri->query_param( i => $ip_address );
+ 
+my $ua = LWP::UserAgent->new( timeout => 5 );
+my $response = $ua->get($uri);
+ 
+die 'Request failed with status ' . $response->code()
+    unless $response->is_success();
+ 
+my %proxy = map { split /=/, $_ } split /;/, $response->content();
+ 
+if ( defined $proxy{err} && length $proxy{err} ) {
+    die "MaxMind returned an error code for the request: $proxy{err}\n";
+}
+else {
+    print "\nMaxMind Proxy data for $ip_address\n\n";
+    for my $field ( sort keys %proxy ) {
+        print sprintf( "  %-20s  %s\n", $field, $proxy{$field} );
+    }
+    print "\n";
+}


### PR DESCRIPTION
Output
This service returns data as a set of comma-separated fields. The individual fields are not escaped or quoted, but they will never contain a comma.

All strings are returned as ASCII.

Name    Type (length)
proxyScore  decimal A score from 0.00-4.00 indicating the likelihood that the user's IP address is an anonymous proxy, open proxy, or VPN.
proxyScore  Likelihood of fraud
0.5 15%
1.0 30%
2.0 60%
3.0+    90% A proxyScore of 0.00 will be returned for a corporate proxy or private IP and an empty string will be returned for an invalid IP.
err enum  
If there was an error or warning with this request, this field contains an error code string.

The possible error codes are:

LICENSE_REQUIRED – you must provide a license key.
MAX_REQUESTS_REACHED – this error will be returned if your account is out of queries or if an invalid license key is provided.
Client Code Examples
Below are some sample clients for this web service. @bet4vlom/name 
